### PR TITLE
Fix file corruption on Ubuntu when resuming a download.

### DIFF
--- a/lib/core/FileHandlerAsyncTask.js
+++ b/lib/core/FileHandlerAsyncTask.js
@@ -9,7 +9,7 @@ var FileHandleGenerator = function(fileName, truncate) {
 var _execute = function(callback) {
 	this.callback = callback;
 	var self = this;
-	var mode = 'a+';
+	var mode = 'r+';
 
 	if (self.truncate === false) {
 		if (fs.existsSync(self.file) === false) {


### PR DESCRIPTION
From https://nodejs.org/api/fs.html#fs_fs_open_path_flags_mode_callback:
On Linux, positional writes don't work when the file is opened in append mode. The kernel ignores the position argument and always appends the data to the end of the file.

Tested on Ubuntu 12.04 and 14.04 - abort during download, resume, check md5.
In a quick test, this also appears to fix https://github.com/tusharmath/Multi-threaded-downloader/issues/36.