### PR TITLE
use graceful-fs instead of fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "main": "index.js",
   "dependencies": {
+    "graceful-fs": "^4.1.3",
     "immutable": "^3.7.5",
     "lodash": "^4.0.0",
     "meow": "^3.7.0",

--- a/src/observables.js
+++ b/src/observables.js
@@ -1,6 +1,6 @@
 const request = require('request')
 const Rx = require('rx')
-const fs = require('fs')
+const fs = require('graceful-fs')
 const _ = require('lodash')
 const u = require('./utils')
 


### PR DESCRIPTION
`graceful-fs` improves a bunch of things in `fs` and is a drop-in replacement.

https://github.com/isaacs/node-graceful-fs

