### PR TITLE
fix(observables): get content-length from a standard request instead of a HEAD request

### DIFF
--- a/perf/server.js
+++ b/perf/server.js
@@ -12,6 +12,7 @@ var options = {
 var httpServer = http.createServer(app)
 var httpsServer = https.createServer(options, app)
 app.use('/files', express.static(path.join(__dirname, '/files')))
+app.get('/fixed-size', (req, res) => res.send('a quick brown fox jumps over the lazy dog'))
 
 const startServer = (app, port) => new Promise((i) => { // eslint-disable-line
   const onClose = () => new Promise((i) => server.close(i)) // eslint-disable-line

--- a/perf/server.js
+++ b/perf/server.js
@@ -12,6 +12,7 @@ var options = {
 var httpServer = http.createServer(app)
 var httpsServer = https.createServer(options, app)
 app.use('/files', express.static(path.join(__dirname, '/files')))
+app.head('/fixed-size', (req, res) => res.status(403).send())
 app.get('/fixed-size', (req, res) => res.send('a quick brown fox jumps over the lazy dog'))
 
 const startServer = (app, port) => new Promise((i) => { // eslint-disable-line

--- a/src/observables.js
+++ b/src/observables.js
@@ -11,6 +11,14 @@ const requestBody = (params) => Rx.Observable.create((observer) => request(param
   .on('error', (error) => observer.onError(error))
 )
 
+const requestContentLength = (params) => requestBody(params)
+  .filter((x) => x.event === 'response')
+  .first()
+  .pluck('message')
+  .tap((x) => x.destroy())
+  .pluck('headers', 'content-length')
+  .map((x) => parseInt(x, 10))
+
 const fsOpen = Rx.Observable.fromNodeCallback(fs.open)
 const fsWrite = Rx.Observable.fromNodeCallback(fs.write)
 const fsTruncate = Rx.Observable.fromNodeCallback(fs.truncate)
@@ -24,9 +32,7 @@ const fsReadJSON = (x) => fsReadBuffer(x).map((x) => JSON.parse(x[1].toString())
 const buffer = (size) => Rx.Observable.just(u.createEmptyBuffer(size))
 module.exports = {
   requestBody,
-  requestContentLength: (x) => requestBody(_.assign({}, x, {method: 'HEAD'}))
-    .pluck('message', 'headers', 'content-length')
-    .map((x) => parseInt(x, 10)),
+  requestContentLength,
   fsOpen,
   fsWrite,
   fsWriteBuffer,

--- a/src/observables.js
+++ b/src/observables.js
@@ -11,11 +11,12 @@ const requestBody = (params) => Rx.Observable.create((observer) => request(param
   .on('error', (error) => observer.onError(error))
 )
 
-const requestContentLength = (params) => requestBody(params)
-  .filter((x) => x.event === 'response')
+const requestHead = (params) => requestBody(params)
   .first()
   .pluck('message')
   .tap((x) => x.destroy())
+
+const requestContentLength = (params) => requestHead(params)
   .pluck('headers', 'content-length')
   .map((x) => parseInt(x, 10))
 
@@ -32,6 +33,7 @@ const fsReadJSON = (x) => fsReadBuffer(x).map((x) => JSON.parse(x[1].toString())
 const buffer = (size) => Rx.Observable.just(u.createEmptyBuffer(size))
 module.exports = {
   requestBody,
+  requestHead,
   requestContentLength,
   fsOpen,
   fsWrite,

--- a/test/integration/test.observable.js
+++ b/test/integration/test.observable.js
@@ -32,4 +32,12 @@ test(async function (t) {
     .toPromise()
   t.same(response.headers['content-length'], '317235')
 })
+
+test(async function (t) {
+  const size = await Observables
+    .requestContentLength({url: 'https://localhost:3101/fixed-size', strictSSL: false})
+    .toPromise()
+  t.same(size, 41)
+})
+
 /*eslint-enable */

--- a/test/integration/test.observable.js
+++ b/test/integration/test.observable.js
@@ -40,4 +40,9 @@ test('requestContentLength', async function (t) {
   t.same(size, 41)
 })
 
+test('requestHead', async function (t) {
+  const response = await Observables.requestHead({url: 'http://localhost:3100/files/pug.jpg'}).toPromise()
+  t.true(response.socket.destroyed)
+})
+
 /*eslint-enable */

--- a/test/integration/test.observable.js
+++ b/test/integration/test.observable.js
@@ -17,7 +17,7 @@ test.after(async function () {
   await closeHttp()
 })
 
-test(async function (t) {
+test('requestBody', async function (t) {
   const response = await Observables
     .requestBody({url: 'http://localhost:3100/files/pug.jpg'})
     .filter((x) => x.event === 'response').pluck('message')
@@ -25,7 +25,7 @@ test(async function (t) {
   t.same(response.headers['content-length'], '317235')
 })
 
-test(async function (t) {
+test('requestBody:https', async function (t) {
   const response = await Observables
     .requestBody({url: 'https://localhost:3101/files/pug.jpg', method: 'HEAD', strictSSL: false})
     .filter((x) => x.event === 'response').pluck('message')
@@ -33,7 +33,7 @@ test(async function (t) {
   t.same(response.headers['content-length'], '317235')
 })
 
-test(async function (t) {
+test('requestContentLength', async function (t) {
   const size = await Observables
     .requestContentLength({url: 'https://localhost:3101/fixed-size', strictSSL: false})
     .toPromise()


### PR DESCRIPTION
- signed URLs from AWS S3 don’t give the content-length in a HEAD request
- this fix uses a standard GET to get the content-length and destroys the request before proceeding to download data, which is practically equivalent to calling HEAD.

I know you weren't keen on doing it this way ... but it does seem reasonably sensible, considering that an aborted GET is effectively the same as a HEAD request ... plus ... it works ;-)

I was able to download a signed AWS URL in multi-parts with this fix